### PR TITLE
Fix Topic#visible_to scope

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2,5 +2,5 @@ class Topic < ActiveRecord::Base
   has_many :posts, dependent: :destroy
   has_many :favorites, dependent: :destroy
 
-  scope :visible_to, -> (user) { user ? all : where(public: true) }
+  scope :visible_to, ->(user) { user ? all : where(public: true) }
 end


### PR DESCRIPTION
This PR fixes an error I ran into when running `rake db:reset`.

The syntax for lambda using arrow (->) requires that *no* space is introduced between the arrow and the arguments list.

@see http://ruby-journal.com/becareful-with-space-in-lambda-hash-rocket-syntax-between-ruby-1-dot-9-and-2-dot-0/