### PR TITLE
Add .ruby-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # Carrierwave image
 public/uploads
+
+# rbenv
+.ruby-version


### PR DESCRIPTION
I currently use Ruby 1.9.3 because there is a bug with Ruby 2.1.* and will_paginate. Cf. #8.

I could switch to Ruby 2.2.* but this version is not available yet with [rbenv](https://github.com/sstephenson/rbenv), so I needed to fallback to the 1.9.3 to be able to run your application.

I defined the Ruby version to be used to run the application using a file named .ruby-version, that rbenv uses to silently switch to the appropriate version of Ruby in that specific directory.

Could you merge this so it's taken into account by .gitignore?